### PR TITLE
Create rich text editor

### DIFF
--- a/src/app/components/EditorContainer/EditorContainer.module.scss
+++ b/src/app/components/EditorContainer/EditorContainer.module.scss
@@ -43,3 +43,9 @@
 .Paragraph {
   margin: 0 0 21px 0;
 }
+.Underline {
+  text-decoration: underline;
+}
+.Strikethrough {
+  text-decoration: line-through;
+}

--- a/src/app/components/EditorContainer/EditorContainer.module.scss
+++ b/src/app/components/EditorContainer/EditorContainer.module.scss
@@ -14,16 +14,17 @@
 .EditorContainer {
   position: relative;
   border: 2px solid $color-black;
-  border-radius: 15px;
-  width: 600px;
+  border-top: none;
+  border-radius: 0 0 15px 15px;
+  width: 800px;
   background: $color-white;
 }
 //Kinda weird that the placeholder is an element outside the input; need css magic to be inline with it
 .Placeholder {
   color: $color-placeholder;
   position: absolute;
-  top: 21px;
-  left: 21px;
+  top: 32px;
+  left: 32px;
   font-size: 21px;
   user-select: none;
   display: inline-block;
@@ -35,7 +36,7 @@
   font-size: 21px;
   line-height: 28px;
   position: relative;
-  padding: 21px;
+  padding: 32px;
   border-radius: 15px;
   outline: 0;
 }

--- a/src/app/components/EditorContainer/EditorContainer.module.scss
+++ b/src/app/components/EditorContainer/EditorContainer.module.scss
@@ -49,3 +49,9 @@
 .Strikethrough {
   text-decoration: line-through;
 }
+.Bold {
+  font-weight: 600;
+}
+.Italic {
+  font-style: italic;
+}

--- a/src/app/components/EditorContainer/index.tsx
+++ b/src/app/components/EditorContainer/index.tsx
@@ -21,6 +21,8 @@ export default function EditorContainer() {
     text: {
       underline: styles.Underline,
       strikethrough: styles.Strikethrough,
+      bold: styles.Bold,
+      italic: styles.Italic,
     },
   };
   /**

--- a/src/app/components/EditorContainer/index.tsx
+++ b/src/app/components/EditorContainer/index.tsx
@@ -6,6 +6,7 @@ import { ContentEditable } from '@lexical/react/LexicalContentEditable';
 import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin';
 import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
+import { ToolbarPlugin } from '../ToolbarPlugin';
 
 //Definitely check out this first and play with the demo: https://lexical.dev/docs/getting-started/react
 export default function EditorContainer() {
@@ -49,6 +50,7 @@ export default function EditorContainer() {
       <div className={styles.Header}>Oh wow a cool editor!</div>
       {/* Pretty cool that you can just add native plugins on a per-need basis. More reading here: https://lexical.dev/docs/react/plugins */}
       <LexicalComposer initialConfig={initialConfig}>
+        <ToolbarPlugin />
         <div className={styles.EditorContainer}>
           <RichTextPlugin
             contentEditable={<ContentEditable className={styles.Input} />}

--- a/src/app/components/EditorContainer/index.tsx
+++ b/src/app/components/EditorContainer/index.tsx
@@ -18,6 +18,10 @@ export default function EditorContainer() {
    */
   const theme: EditorThemeClasses = {
     paragraph: styles.Paragraph,
+    text: {
+      underline: styles.Underline,
+      strikethrough: styles.Strikethrough,
+    },
   };
   /**
    * Custom handler for when content changes in the editor

--- a/src/app/components/EditorContainer/index.tsx
+++ b/src/app/components/EditorContainer/index.tsx
@@ -1,7 +1,7 @@
 import styles from './EditorContainer.module.scss';
 import { $getRoot, $getSelection, EditorState, EditorThemeClasses } from 'lexical';
 import { LexicalComposer, InitialConfigType } from '@lexical/react/LexicalComposer';
-import { PlainTextPlugin } from '@lexical/react/LexicalPlainTextPlugin';
+import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { ContentEditable } from '@lexical/react/LexicalContentEditable';
 import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin';
@@ -50,7 +50,7 @@ export default function EditorContainer() {
       {/* Pretty cool that you can just add native plugins on a per-need basis. More reading here: https://lexical.dev/docs/react/plugins */}
       <LexicalComposer initialConfig={initialConfig}>
         <div className={styles.EditorContainer}>
-          <PlainTextPlugin
+          <RichTextPlugin
             contentEditable={<ContentEditable className={styles.Input} />}
             placeholder={<div className={styles.Placeholder}>Try me...</div>}
             ErrorBoundary={LexicalErrorBoundary}

--- a/src/app/components/ToolbarPlugin/ToolbarPlugin.module.scss
+++ b/src/app/components/ToolbarPlugin/ToolbarPlugin.module.scss
@@ -1,0 +1,11 @@
+@import '../../../assets/styles/variables.scss';
+
+.Container {
+  width: 800px;
+  border: 2px solid $color-black;
+  border-bottom: none;
+  background-color: $color-white;
+  border-radius: 15px 15px 0 0;
+  display: flex;
+  justify-content: center;
+}

--- a/src/app/components/ToolbarPlugin/ToolbarPlugin.module.scss
+++ b/src/app/components/ToolbarPlugin/ToolbarPlugin.module.scss
@@ -9,3 +9,25 @@
   display: flex;
   justify-content: center;
 }
+.Tools {
+  background-color: #eff1f5;
+  padding: 9px 16px;
+  border-radius: 0 0 8px 8px;
+}
+.ToolButton {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 21px;
+  color: $color-default;
+  border: none;
+  background-color: transparent;
+  border-radius: 4px;
+  min-width: 24px;
+
+  &:hover {
+    background-color: #b0b4b7;
+  }
+  &:active {
+    background-color: #9fa3a6;
+  }
+}

--- a/src/app/components/ToolbarPlugin/ToolbarPlugin.module.scss
+++ b/src/app/components/ToolbarPlugin/ToolbarPlugin.module.scss
@@ -10,7 +10,7 @@
   justify-content: center;
 }
 .Tools {
-  background-color: #eff1f5;
+  background-color: $bg-color-toolbar;
   padding: 9px 16px;
   border-radius: 0 0 8px 8px;
 }
@@ -25,9 +25,12 @@
   min-width: 24px;
 
   &:hover {
-    background-color: #b0b4b7;
+    background-color: $bg-color-toolbar-button-hover;
   }
   &:active {
-    background-color: #9fa3a6;
+    background-color: $bg-color-toolbar-button-active;
   }
+}
+.Active {
+  background-color: $bg-color-toolbar-button-active;
 }

--- a/src/app/components/ToolbarPlugin/index.tsx
+++ b/src/app/components/ToolbarPlugin/index.tsx
@@ -37,6 +37,8 @@ export function ToolbarPlugin() {
       COMMAND_PRIORITY_CRITICAL
     );
   }, [editor, updateToolbar]);
+
+  useEffect(() => {});
   return (
     <div className={styles.Container}>
       <div className={styles.Tools}>

--- a/src/app/components/ToolbarPlugin/index.tsx
+++ b/src/app/components/ToolbarPlugin/index.tsx
@@ -9,7 +9,32 @@ export function ToolbarPlugin() {
 
   return (
     <div className={styles.Container}>
-      <button onClick={() => activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold')}>B</button>
+      <div className={styles.Tools}>
+        <button
+          className={styles.ToolButton}
+          onClick={() => activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold')}
+        >
+          B
+        </button>
+        <button
+          className={styles.ToolButton}
+          onClick={() => activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic')}
+        >
+          I
+        </button>
+        <button
+          className={styles.ToolButton}
+          onClick={() => activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'strikethrough')}
+        >
+          S
+        </button>
+        <button
+          className={styles.ToolButton}
+          onClick={() => activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline')}
+        >
+          U
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/app/components/ToolbarPlugin/index.tsx
+++ b/src/app/components/ToolbarPlugin/index.tsx
@@ -19,7 +19,7 @@ export function ToolbarPlugin() {
 
   const updateToolbar = useCallback(() => {
     const selection = $getSelection() as RangeSelection;
-
+    console.log('wtf');
     setIsBold(selection.hasFormat('bold'));
     setIsItalic(selection.hasFormat('italic'));
     setIsUnderline(selection.hasFormat('underline'));

--- a/src/app/components/ToolbarPlugin/index.tsx
+++ b/src/app/components/ToolbarPlugin/index.tsx
@@ -1,0 +1,15 @@
+import styles from './ToolbarPlugin.module.scss';
+import { FORMAT_TEXT_COMMAND } from 'lexical';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { useState } from 'react';
+
+export function ToolbarPlugin() {
+  const [editor] = useLexicalComposerContext();
+  const [activeEditor, setActiveEditor] = useState(editor);
+
+  return (
+    <div className={styles.Container}>
+      <button onClick={() => activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold')}>B</button>
+    </div>
+  );
+}

--- a/src/app/components/ToolbarPlugin/index.tsx
+++ b/src/app/components/ToolbarPlugin/index.tsx
@@ -9,6 +9,14 @@ import {
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { useCallback, useEffect, useState } from 'react';
 
+/**
+ * Plugins are essentially react components that you can use inside the LexicalComposer wrapper
+ * It's pretty neat since the composer uses Context, we can get the editor state by just calling a native function (editor instance is passed through all the children)
+ * There are native plugins in lexical already but majority of use cases would require us creating custom plugins
+ * I haven't fully grasped everything that's happening yet but I'm slowing understanding all the moving parts
+ * When you're finally done with the plugin, you can just place it inside the EditorContainer under LexicalComposer
+ * @returns
+ */
 export function ToolbarPlugin() {
   const [editor] = useLexicalComposerContext();
   const [activeEditor, setActiveEditor] = useState(editor);
@@ -17,6 +25,11 @@ export function ToolbarPlugin() {
   const [isUnderline, setIsUnderline] = useState(false);
   const [isStrikethrough, setIsStrikethrough] = useState(false);
 
+  /**
+   * Updates the styling of the toolbar
+   * Currently only controls if the text format buttons are active
+   * Probably would get more complicated with more tool actions
+   **/
   const updateToolbar = useCallback(() => {
     const selection = $getSelection() as RangeSelection;
     setIsBold(selection.hasFormat('bold'));
@@ -25,11 +38,18 @@ export function ToolbarPlugin() {
     setIsStrikethrough(selection.hasFormat('strikethrough'));
   }, [activeEditor]);
 
+  /**
+   * Commands lets you register event listeners like `key_enter_command` and contextually react to them wherever & however you'd like
+   * This is pretty powerful as you can control pretty much anything that happens in the dom and act accordingly
+   * There are already a handful of existing commands you can register under LexicalCommands.d.ts but you can also create custom ones
+   * I figure this is the concept that you'll use to do the all fancy editor interactions
+   * Only caveat is that there's not really a detailed explanation of what the existing commands do; guess it's somewhat self-explanatory but still you'd have to test them to be sure
+   * Below listens for any changes in the selection (highlight) of the editor and updates the state of the toolbar buttons
+   */
   useEffect(() => {
     return editor.registerCommand(
       SELECTION_CHANGE_COMMAND,
       (_payload, newEditor) => {
-        console.log('hello');
         updateToolbar();
         setActiveEditor(newEditor);
         return false;
@@ -38,6 +58,12 @@ export function ToolbarPlugin() {
     );
   }, [editor, updateToolbar]);
 
+  /**
+   * Listeners are a mechanism that lets the Editor instance inform the user when a certain operation has occured
+   * Different from commands as they listen for user events and this listens for when the editor has done an event
+   * Again you'd probably use this in tandem with commands for all the fancy interactions
+   * Below listens for any updates to the DOM and updates the toolbar state if it does
+   */
   useEffect(() => {
     return activeEditor.registerUpdateListener(({ editorState }) => {
       editorState.read(() => {
@@ -47,6 +73,7 @@ export function ToolbarPlugin() {
   }, [activeEditor, updateToolbar]);
   return (
     <div className={styles.Container}>
+      {/* Commands can be dispatched anywhere as long as you have access to the editor state */}
       <div className={styles.Tools}>
         <button
           className={`${styles.ToolButton} ${isBold ? styles.Active : ''}`}

--- a/src/app/components/ToolbarPlugin/index.tsx
+++ b/src/app/components/ToolbarPlugin/index.tsx
@@ -19,7 +19,6 @@ export function ToolbarPlugin() {
 
   const updateToolbar = useCallback(() => {
     const selection = $getSelection() as RangeSelection;
-    console.log('wtf');
     setIsBold(selection.hasFormat('bold'));
     setIsItalic(selection.hasFormat('italic'));
     setIsUnderline(selection.hasFormat('underline'));
@@ -30,6 +29,7 @@ export function ToolbarPlugin() {
     return editor.registerCommand(
       SELECTION_CHANGE_COMMAND,
       (_payload, newEditor) => {
+        console.log('hello');
         updateToolbar();
         setActiveEditor(newEditor);
         return false;
@@ -38,7 +38,13 @@ export function ToolbarPlugin() {
     );
   }, [editor, updateToolbar]);
 
-  useEffect(() => {});
+  useEffect(() => {
+    return activeEditor.registerUpdateListener(({ editorState }) => {
+      editorState.read(() => {
+        updateToolbar();
+      });
+    });
+  }, [activeEditor, updateToolbar]);
   return (
     <div className={styles.Container}>
       <div className={styles.Tools}>

--- a/src/app/components/ToolbarPlugin/index.tsx
+++ b/src/app/components/ToolbarPlugin/index.tsx
@@ -1,35 +1,65 @@
 import styles from './ToolbarPlugin.module.scss';
-import { FORMAT_TEXT_COMMAND } from 'lexical';
+import {
+  $getSelection,
+  COMMAND_PRIORITY_CRITICAL,
+  FORMAT_TEXT_COMMAND,
+  RangeSelection,
+  SELECTION_CHANGE_COMMAND,
+} from 'lexical';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export function ToolbarPlugin() {
   const [editor] = useLexicalComposerContext();
   const [activeEditor, setActiveEditor] = useState(editor);
+  const [isBold, setIsBold] = useState(false);
+  const [isItalic, setIsItalic] = useState(false);
+  const [isUnderline, setIsUnderline] = useState(false);
+  const [isStrikethrough, setIsStrikethrough] = useState(false);
 
+  const updateToolbar = useCallback(() => {
+    const selection = $getSelection() as RangeSelection;
+
+    setIsBold(selection.hasFormat('bold'));
+    setIsItalic(selection.hasFormat('italic'));
+    setIsUnderline(selection.hasFormat('underline'));
+    setIsStrikethrough(selection.hasFormat('strikethrough'));
+  }, [activeEditor]);
+
+  useEffect(() => {
+    return editor.registerCommand(
+      SELECTION_CHANGE_COMMAND,
+      (_payload, newEditor) => {
+        updateToolbar();
+        setActiveEditor(newEditor);
+        return false;
+      },
+      COMMAND_PRIORITY_CRITICAL
+    );
+  }, [editor, updateToolbar]);
   return (
     <div className={styles.Container}>
       <div className={styles.Tools}>
         <button
-          className={styles.ToolButton}
+          className={`${styles.ToolButton} ${isBold ? styles.Active : ''}`}
           onClick={() => activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold')}
         >
           B
         </button>
         <button
-          className={styles.ToolButton}
+          className={`${styles.ToolButton} ${isItalic ? styles.Active : ''}`}
           onClick={() => activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic')}
         >
           I
         </button>
         <button
-          className={styles.ToolButton}
+          className={`${styles.ToolButton} ${isStrikethrough ? styles.Active : ''}`}
           onClick={() => activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'strikethrough')}
         >
           S
         </button>
         <button
-          className={styles.ToolButton}
+          className={`${styles.ToolButton} ${isUnderline ? styles.Active : ''}`}
           onClick={() => activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline')}
         >
           U

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -5,4 +5,7 @@ $color-black: #000;
 $color-placeholder: rgb(188, 188, 188);
 
 //Background color
-$bg-color-main: #b4f3fb;
+$bg-color-main: #61e6f8;
+$bg-color-toolbar: #eff1f5;
+$bg-color-toolbar-button-hover: #b0b4b7;
+$bg-color-toolbar-button-active: #9fa3a6;


### PR DESCRIPTION
#### Context
Since we don't really have much use for plain text editors, this replaces it with the Rich Text plugin. Not as simple as I initially thought it would be. Lexical really just gives you the building blocks and nothing else, it's up to you to build everything from the ground up. That being said, how they handle user/editor interactions and offer us a relatively straightforward way to react to them is pretty cool. Albeit there's a bit of a learning curve to figure out the concepts

![rich text editor base](https://user-images.githubusercontent.com/42207245/214947200-3977b405-b82e-4948-b605-ed83a180fa53.gif)

#### Change
- Replace plain text plugin to rich text
- Create custom toolbar plugin
- Add main text format buttons and themes
- Add listens and commands
