### PR TITLE
Add custom merge tag node

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,6 +1,7 @@
 @import './assets/styles/variables.scss';
+@import './assets/styles/globals.scss';
 
-.Container {
+.App {
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.8);
   color: $color-default;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import styles from './App.module.scss';
+import './App.scss';
 import EditorContainer from './app/components/EditorContainer';
 
 function App() {
   return (
-    <div className={styles.Container}>
+    <div className="App">
       <EditorContainer />
     </div>
   );

--- a/src/app/components/CustomNodes/MergeTagNode/index.tsx
+++ b/src/app/components/CustomNodes/MergeTagNode/index.tsx
@@ -15,17 +15,15 @@ export class MergeTagNode extends TextNode {
   }
   createDOM(config: EditorConfig): HTMLElement {
     const element = super.createDOM(config);
-    element.style.color = 'blue';
+    element.className = 'MergeTag';
     return element;
   }
   updateDOM(prevNode: TextNode, dom: HTMLElement, config: EditorConfig): boolean {
-    const isUpdated = super.updateDOM(prevNode, dom, config);
-    dom.style.color = 'blue';
-    return isUpdated;
+    return false;
   }
 }
 export function $createMergeTag(text: string) {
-  return new MergeTagNode(text);
+  return new MergeTagNode(text).setMode('token');
 }
 export function $isMergeTag(node: LexicalNode) {
   return node instanceof MergeTagNode;

--- a/src/app/components/CustomNodes/MergeTagNode/index.tsx
+++ b/src/app/components/CustomNodes/MergeTagNode/index.tsx
@@ -1,5 +1,15 @@
 import { NodeKey, TextNode, LexicalNode, EditorConfig } from 'lexical';
 
+/**
+ * Nodes are a core concept in Lexical
+ * They form the visual editor view as well as represent the underlying data model of the editor
+ * For more reading, see https://lexical.dev/docs/concepts/nodes
+ * There are 5 base nodes but what we're looking for are the 3 nodes that can be extended
+ * - ElementNode: mainly used as parents for other nodes
+ * - TextNode: Leaf type of node that contains text
+ * - DecoratorNode: Wrapper node to insert arbitrary view inside the editor
+ * Basically any special tags and entities you'd want to insert in the editor, you'd use these
+ */
 export class MergeTagNode extends TextNode {
   mergeTagText: string;
 
@@ -22,6 +32,11 @@ export class MergeTagNode extends TextNode {
     return false;
   }
 }
+/**
+ * Create a merge tag node
+ * Lexical states that it's good etiquette to name utility functions from custom nodes with $
+ * An important note: To properly create custom nodes, you'd need to register them to the editor by describing them in the editorConfig
+ */
 export function $createMergeTag(text: string) {
   return new MergeTagNode(text).setMode('token');
 }

--- a/src/app/components/CustomNodes/MergeTagNode/index.tsx
+++ b/src/app/components/CustomNodes/MergeTagNode/index.tsx
@@ -1,0 +1,22 @@
+import { NodeKey, TextNode, LexicalNode } from 'lexical';
+
+export class MergeTagNode extends TextNode {
+  mergeTagText: string;
+
+  constructor(text: string, key?: NodeKey) {
+    super(text, key);
+    this.mergeTagText = text;
+  }
+  static getType(): string {
+    return 'merge-tag';
+  }
+  static clone(node: MergeTagNode): MergeTagNode {
+    return new MergeTagNode(node.__text, node.__key);
+  }
+}
+export function $createMergeTag(text: string) {
+  return new MergeTagNode(text);
+}
+export function $isMergeTag(node: LexicalNode) {
+  return node instanceof MergeTagNode;
+}

--- a/src/app/components/CustomNodes/MergeTagNode/index.tsx
+++ b/src/app/components/CustomNodes/MergeTagNode/index.tsx
@@ -1,4 +1,4 @@
-import { NodeKey, TextNode, LexicalNode } from 'lexical';
+import { NodeKey, TextNode, LexicalNode, EditorConfig } from 'lexical';
 
 export class MergeTagNode extends TextNode {
   mergeTagText: string;
@@ -12,6 +12,16 @@ export class MergeTagNode extends TextNode {
   }
   static clone(node: MergeTagNode): MergeTagNode {
     return new MergeTagNode(node.__text, node.__key);
+  }
+  createDOM(config: EditorConfig): HTMLElement {
+    const element = super.createDOM(config);
+    element.style.color = 'blue';
+    return element;
+  }
+  updateDOM(prevNode: TextNode, dom: HTMLElement, config: EditorConfig): boolean {
+    const isUpdated = super.updateDOM(prevNode, dom, config);
+    dom.style.color = 'blue';
+    return isUpdated;
   }
 }
 export function $createMergeTag(text: string) {

--- a/src/app/components/EditorContainer/index.tsx
+++ b/src/app/components/EditorContainer/index.tsx
@@ -7,6 +7,7 @@ import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin';
 import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
 import { ToolbarPlugin } from '../ToolbarPlugin';
+import { MergeTagNode } from '../CustomNodes/MergeTagNode';
 
 //Definitely check out this first and play with the demo: https://lexical.dev/docs/getting-started/react
 export default function EditorContainer() {
@@ -50,6 +51,7 @@ export default function EditorContainer() {
     namespace: 'Lexi-chan',
     theme,
     onError,
+    nodes: [MergeTagNode],
   };
   return (
     <div className={styles.Container}>

--- a/src/app/components/EditorContainer/index.tsx
+++ b/src/app/components/EditorContainer/index.tsx
@@ -51,7 +51,7 @@ export default function EditorContainer() {
     namespace: 'Lexi-chan',
     theme,
     onError,
-    nodes: [MergeTagNode],
+    nodes: [MergeTagNode], //Custom Nodes
   };
   return (
     <div className={styles.Container}>

--- a/src/app/components/ToolbarPlugin/ToolbarPlugin.module.scss
+++ b/src/app/components/ToolbarPlugin/ToolbarPlugin.module.scss
@@ -23,12 +23,16 @@
   background-color: transparent;
   border-radius: 4px;
   min-width: 24px;
+  margin-right: 2px;
 
   &:hover {
     background-color: $bg-color-toolbar-button-hover;
   }
   &:active {
     background-color: $bg-color-toolbar-button-active;
+  }
+  &:last-child {
+    margin-right: 0;
   }
 }
 .Active {

--- a/src/app/components/ToolbarPlugin/index.tsx
+++ b/src/app/components/ToolbarPlugin/index.tsx
@@ -2,12 +2,16 @@ import styles from './ToolbarPlugin.module.scss';
 import {
   $getSelection,
   COMMAND_PRIORITY_CRITICAL,
+  COMMAND_PRIORITY_EDITOR,
+  createCommand,
   FORMAT_TEXT_COMMAND,
+  LexicalCommand,
   RangeSelection,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { useCallback, useEffect, useState } from 'react';
+import { $createMergeTag } from '../CustomNodes/MergeTagNode';
 
 /**
  * Plugins are essentially react components that you can use inside the LexicalComposer wrapper
@@ -71,6 +75,22 @@ export function ToolbarPlugin() {
       });
     });
   }, [activeEditor, updateToolbar]);
+
+  const CREATE_MERGE_TAG_COMMAND: LexicalCommand<undefined> = createCommand();
+
+  useEffect(() => {
+    return editor.registerCommand(
+      CREATE_MERGE_TAG_COMMAND,
+      () => {
+        const selection = $getSelection() as RangeSelection;
+        console.log('create merge tag');
+        const newMergeTag = $createMergeTag(selection.getTextContent());
+        console.log(newMergeTag.getType());
+        return false;
+      },
+      COMMAND_PRIORITY_EDITOR
+    );
+  });
   return (
     <div className={styles.Container}>
       {/* Commands can be dispatched anywhere as long as you have access to the editor state */}
@@ -98,6 +118,14 @@ export function ToolbarPlugin() {
           onClick={() => activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline')}
         >
           U
+        </button>
+        <button
+          className={`${styles.ToolButton}`}
+          onClick={() => {
+            activeEditor.dispatchCommand(CREATE_MERGE_TAG_COMMAND, undefined);
+          }}
+        >
+          M
         </button>
       </div>
     </div>

--- a/src/app/components/ToolbarPlugin/index.tsx
+++ b/src/app/components/ToolbarPlugin/index.tsx
@@ -83,9 +83,8 @@ export function ToolbarPlugin() {
       CREATE_MERGE_TAG_COMMAND,
       () => {
         const selection = $getSelection() as RangeSelection;
-        console.log('create merge tag');
         const newMergeTag = $createMergeTag(selection.getTextContent());
-        console.log(newMergeTag.getType());
+        selection.insertNodes([newMergeTag]);
         return false;
       },
       COMMAND_PRIORITY_EDITOR

--- a/src/assets/styles/globals.scss
+++ b/src/assets/styles/globals.scss
@@ -1,0 +1,11 @@
+@import '../styles/variables.scss';
+
+.MergeTag {
+  color: $label-blue;
+  background-color: #d8e8f6;
+  padding: 2px 4px;
+  line-height: 24px;
+  box-shadow: inset 0px -1px 0px #3a8dd1;
+  display: inline;
+  pointer-events: none;
+}

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -9,3 +9,6 @@ $bg-color-main: #61e6f8;
 $bg-color-toolbar: #eff1f5;
 $bg-color-toolbar-button-hover: #b0b4b7;
 $bg-color-toolbar-button-active: #9fa3a6;
+
+//Label color
+$label-blue: #3a8dd1;


### PR DESCRIPTION
#### Context
This touches the concepts of nodes in lexical. Nodes are pretty much a core concept so I figure I'll be working on it quite a bit. They form the visual editor view as well as represent the underlying data model stored in the editor at any given time. 
More reading here: https://lexical.dev/docs/concepts/nodes but what would be really important is being able to extend some nodes for our own use cases

![merge tag custom node](https://user-images.githubusercontent.com/42207245/215203317-a58b192e-0e38-46cb-8b25-86558e4fa99d.gif)

#### Change
- Create custom merge tag node
- Add node to editor config
- Add style

#### Considerations
I extended the TextNode for this but I realised as I was finishing up this branch that it might be a better choice to use the DecoratorNode instead. Will look into it more later on but this is good enough for a starter