### PR TITLE
Create tag as decorator node

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
+    "downshift": "^7.2.0",
     "lexical": "^0.7.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/app/components/CustomNodes/MergeTagNode/index.tsx
+++ b/src/app/components/CustomNodes/MergeTagNode/index.tsx
@@ -10,6 +10,7 @@ import { ReactNode } from 'react';
  * - TextNode: Leaf type of node that contains text
  * - DecoratorNode: Wrapper node to insert arbitrary view inside the editor
  * Basically any special tags and entities you'd want to insert in the editor, you'd use these
+ * Experimentally using DecoratorNode below to render custom html tags; still torn between this and TextNode
  */
 export class MergeTagNode extends DecoratorNode<ReactNode> {
   mergeTagText: string;

--- a/src/app/components/CustomNodes/MergeTagNode/index.tsx
+++ b/src/app/components/CustomNodes/MergeTagNode/index.tsx
@@ -1,4 +1,5 @@
-import { NodeKey, TextNode, LexicalNode, EditorConfig } from 'lexical';
+import { NodeKey, DecoratorNode, LexicalNode, EditorConfig, LexicalEditor } from 'lexical';
+import { ReactNode } from 'react';
 
 /**
  * Nodes are a core concept in Lexical
@@ -10,11 +11,11 @@ import { NodeKey, TextNode, LexicalNode, EditorConfig } from 'lexical';
  * - DecoratorNode: Wrapper node to insert arbitrary view inside the editor
  * Basically any special tags and entities you'd want to insert in the editor, you'd use these
  */
-export class MergeTagNode extends TextNode {
+export class MergeTagNode extends DecoratorNode<ReactNode> {
   mergeTagText: string;
 
   constructor(text: string, key?: NodeKey) {
-    super(text, key);
+    super(key);
     this.mergeTagText = text;
   }
   static getType(): string {
@@ -23,13 +24,17 @@ export class MergeTagNode extends TextNode {
   static clone(node: MergeTagNode): MergeTagNode {
     return new MergeTagNode(node.__text, node.__key);
   }
-  createDOM(config: EditorConfig): HTMLElement {
-    const element = super.createDOM(config);
-    element.className = 'MergeTag';
-    return element;
+  createDOM(_config: EditorConfig, _editor: LexicalEditor): HTMLElement {
+    return document.createElement('merge-tag');
   }
-  updateDOM(prevNode: TextNode, dom: HTMLElement, config: EditorConfig): boolean {
+  updateDOM(_prevNode: unknown, _dom: HTMLElement, _config: EditorConfig): boolean {
     return false;
+  }
+  decorate(): ReactNode {
+    return this.mergeTagText;
+  }
+  isIsolated(): boolean {
+    return true;
   }
 }
 /**
@@ -38,7 +43,7 @@ export class MergeTagNode extends TextNode {
  * An important note: To properly create custom nodes, you'd need to register them to the editor by describing them in the editorConfig
  */
 export function $createMergeTag(text: string) {
-  return new MergeTagNode(text).setMode('token');
+  return new MergeTagNode(text);
 }
 export function $isMergeTag(node: LexicalNode) {
   return node instanceof MergeTagNode;

--- a/src/app/components/ToolbarPlugin/ToolbarPlugin.module.scss
+++ b/src/app/components/ToolbarPlugin/ToolbarPlugin.module.scss
@@ -49,3 +49,6 @@
   margin-right: 4px;
   border-left: 2px solid $color-default;
 }
+.Caret {
+  margin-left: 12px;
+}

--- a/src/app/components/ToolbarPlugin/ToolbarPlugin.module.scss
+++ b/src/app/components/ToolbarPlugin/ToolbarPlugin.module.scss
@@ -17,6 +17,7 @@
   border-radius: 0 0 8px 8px;
 }
 .ToolButton {
+  position: relative;
   display: flex;
   align-items: center;
   cursor: pointer;
@@ -28,6 +29,7 @@
   min-width: 24px;
   padding: 3px 6px;
   margin-right: 2px;
+  transition: background-color 0.1s ease;
 
   &:hover {
     background-color: $bg-color-toolbar-button-hover;
@@ -42,6 +44,9 @@
 .Active {
   background-color: $bg-color-toolbar-button-active;
 }
+.MenuActive {
+  background-color: $bg-color-toolbar-button-hover;
+}
 .Divider {
   width: 1px;
   height: 100%;
@@ -51,4 +56,29 @@
 }
 .Caret {
   margin-left: 12px;
+}
+.TagMenu {
+  display: flex;
+  flex-direction: column;
+  min-width: 120px;
+  padding: 16px;
+  z-index: 100;
+  position: absolute;
+  background-color: $bg-color-toolbar;
+  box-shadow: 0 0px 8px rgba(0, 0, 0, 0.1);
+  top: 42px;
+  left: 0;
+  border-radius: 8px;
+}
+.TagItem {
+  display: flex;
+  padding: 4px;
+  text-align: center;
+  align-items: center;
+  line-height: 28px;
+  border-radius: 8px;
+  transition: background-color 0.1s ease;
+  &:hover {
+    background-color: $bg-color-toolbar-button-hover;
+  }
 }

--- a/src/app/components/ToolbarPlugin/index.tsx
+++ b/src/app/components/ToolbarPlugin/index.tsx
@@ -62,6 +62,26 @@ export function ToolbarPlugin() {
       COMMAND_PRIORITY_CRITICAL
     );
   }, [editor, updateToolbar]);
+  /**
+   * As stated above, you are able create custom commands.
+   * You can control whatever is passed in and the necessary interactions that follows
+   * In this case, this creates a new command and registers it in inserting a merge tag in the selectedSelection
+   * And this command can be called wherever you need it
+   */
+  const CREATE_MERGE_TAG_COMMAND: LexicalCommand<undefined> = createCommand();
+  useEffect(() => {
+    return editor.registerCommand(
+      CREATE_MERGE_TAG_COMMAND,
+      (payload: string) => {
+        const selection = $getSelection() as RangeSelection;
+        const newMergeTag = $createMergeTag(payload);
+        selection.insertNodes([newMergeTag]);
+        selection.insertText(' ');
+        return false;
+      },
+      COMMAND_PRIORITY_EDITOR
+    );
+  });
 
   /**
    * Listeners are a mechanism that lets the Editor instance inform the user when a certain operation has occured
@@ -77,21 +97,6 @@ export function ToolbarPlugin() {
     });
   }, [activeEditor, updateToolbar]);
 
-  const CREATE_MERGE_TAG_COMMAND: LexicalCommand<undefined> = createCommand();
-
-  useEffect(() => {
-    return editor.registerCommand(
-      CREATE_MERGE_TAG_COMMAND,
-      (payload: string) => {
-        const selection = $getSelection() as RangeSelection;
-        const newMergeTag = $createMergeTag(payload);
-        selection.insertNodes([newMergeTag]);
-        selection.insertText(' ');
-        return false;
-      },
-      COMMAND_PRIORITY_EDITOR
-    );
-  });
   const tagItems = [
     { name: 'tag_name_1', label: 'Tag Name 1' },
     {
@@ -128,10 +133,12 @@ export function ToolbarPlugin() {
           <i className="fa-solid fa-underline"></i>
         </button>
         <span className={styles.Divider}></span>
+        {/* Experimenting with downshift for easier select dropdown implementation; kinda interesting but not sure if I like it so much */}
         <DownShift
-          onChange={(selected, action) => {
+          onSelect={(selected, action) => {
             if (selected) {
               activeEditor.dispatchCommand(CREATE_MERGE_TAG_COMMAND, selected.label);
+              action.reset();
               action.toggleMenu();
             }
           }}

--- a/src/app/components/ToolbarPlugin/index.tsx
+++ b/src/app/components/ToolbarPlugin/index.tsx
@@ -86,6 +86,7 @@ export function ToolbarPlugin() {
         const selection = $getSelection() as RangeSelection;
         const newMergeTag = $createMergeTag(payload);
         selection.insertNodes([newMergeTag]);
+        selection.insertText(' ');
         return false;
       },
       COMMAND_PRIORITY_EDITOR
@@ -128,8 +129,11 @@ export function ToolbarPlugin() {
         </button>
         <span className={styles.Divider}></span>
         <DownShift
-          onChange={(value) => {
-            value && activeEditor.dispatchCommand(CREATE_MERGE_TAG_COMMAND, value);
+          onChange={(selected, action) => {
+            if (selected) {
+              activeEditor.dispatchCommand(CREATE_MERGE_TAG_COMMAND, selected.label);
+              action.toggleMenu();
+            }
           }}
           itemToString={(item) => (item ? item.label : '')}
         >

--- a/src/app/components/ToolbarPlugin/index.tsx
+++ b/src/app/components/ToolbarPlugin/index.tsx
@@ -126,6 +126,7 @@ export function ToolbarPlugin() {
           }}
         >
           <i className="fa-regular fa-clipboard"></i>
+          <i className={`${styles.Caret} fa-solid fa-caret-down`}></i>
         </button>
       </div>
     </div>

--- a/src/app/components/ToolbarPlugin/index.tsx
+++ b/src/app/components/ToolbarPlugin/index.tsx
@@ -12,6 +12,7 @@ import {
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { useCallback, useEffect, useState } from 'react';
 import { $createMergeTag } from '../CustomNodes/MergeTagNode';
+import DownShift from 'downshift';
 
 /**
  * Plugins are essentially react components that you can use inside the LexicalComposer wrapper
@@ -81,15 +82,22 @@ export function ToolbarPlugin() {
   useEffect(() => {
     return editor.registerCommand(
       CREATE_MERGE_TAG_COMMAND,
-      () => {
+      (payload: string) => {
         const selection = $getSelection() as RangeSelection;
-        const newMergeTag = $createMergeTag(selection.getTextContent());
+        const newMergeTag = $createMergeTag(payload);
         selection.insertNodes([newMergeTag]);
         return false;
       },
       COMMAND_PRIORITY_EDITOR
     );
   });
+  const tagItems = [
+    { name: 'tag_name_1', label: 'Tag Name 1' },
+    {
+      name: 'tag_name_2',
+      label: 'Tag Name 2',
+    },
+  ];
   return (
     <div className={styles.Container}>
       {/* Commands can be dispatched anywhere as long as you have access to the editor state */}
@@ -119,15 +127,38 @@ export function ToolbarPlugin() {
           <i className="fa-solid fa-underline"></i>
         </button>
         <span className={styles.Divider}></span>
-        <button
-          className={`${styles.ToolButton}`}
-          onClick={() => {
-            activeEditor.dispatchCommand(CREATE_MERGE_TAG_COMMAND, undefined);
+        <DownShift
+          onChange={(value) => {
+            value && activeEditor.dispatchCommand(CREATE_MERGE_TAG_COMMAND, value);
           }}
+          itemToString={(item) => (item ? item.label : '')}
         >
-          <i className="fa-regular fa-clipboard"></i>
-          <i className={`${styles.Caret} fa-solid fa-caret-down`}></i>
-        </button>
+          {({ isOpen, getToggleButtonProps, getMenuProps, getItemProps }) => {
+            return (
+              <div
+                className={`${styles.ToolButton} ${isOpen ? styles.MenuActive : ''}`}
+                {...getToggleButtonProps()}
+              >
+                <i className="fa-regular fa-clipboard"></i>
+                <i className={`${styles.Caret} fa-solid fa-caret-down`}></i>
+                {isOpen ? (
+                  <div className={styles.TagMenu} {...getMenuProps()}>
+                    {tagItems.map((item, index) => {
+                      return (
+                        <span
+                          className={styles.TagItem}
+                          {...getItemProps({ key: item.name, index, item })}
+                        >
+                          <span>{item.label}</span>
+                        </span>
+                      );
+                    })}
+                  </div>
+                ) : null}
+              </div>
+            );
+          }}
+        </DownShift>
       </div>
     </div>
   );

--- a/src/assets/styles/globals.scss
+++ b/src/assets/styles/globals.scss
@@ -1,6 +1,6 @@
 @import '../styles/variables.scss';
 
-.MergeTag {
+merge-tag {
   color: $label-blue;
   background-color: #d8e8f6;
   padding: 2px 4px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,6 +1138,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.14.8":
+  version "7.20.13"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.13.tgz#7055ab8a7cff2b8f6058bf6ae45ff84ad2aded4b"
+  integrity sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.3.3":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -3730,6 +3737,11 @@ compression@^1.7.4:
     safe-buffer "5.1.2"
     vary "~1.1.2"
 
+compute-scroll-into-view@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-2.0.4.tgz#2b444b2b9e4724819d2531efacb7ac094155fdf6"
+  integrity sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -4358,6 +4370,17 @@ dotenv@^8.0.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
+
+downshift@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-7.2.0.tgz#f2a2777253a8ca26ca56c38caa8e75f76a6ab346"
+  integrity sha512-dEn1Sshe7iTelUhmdbmiJhtIiwIBxBV8p15PuvEBh0qZcHXZnEt0geuCIIkCL4+ooaKRuLE0Wc+Fz9SwWuBIyg==
+  dependencies:
+    "@babel/runtime" "^7.14.8"
+    compute-scroll-into-view "^2.0.4"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
+    tslib "^2.3.0"
 
 duplexer@^0.1.2:
   version "0.1.2"
@@ -8233,7 +8256,7 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.8.1:
+prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -8393,7 +8416,7 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^17.0.1:
+react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -9575,7 +9598,7 @@ tslib@^1.14.1, tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2:
+tslib@^2, tslib@^2.3.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==


### PR DESCRIPTION
#### Context
Wanted to check how extending DecoratorNodes would look like and actually kinda liked it. Albeit there's some issues I've encountered with it, specifically with the selection deletion. Semantically this node seems like the most similar to how we treat special tags in draftjs but TextNode seems so powerfully simple that it's making me second guess what to pick. Anyhow, it's a question for another time

Also changed the replacing implementation to an insert to mirror how this would eventually look. Didn't want to put too much effort in the dropdowns so installed [Downshift](https://www.downshift-js.com/). Never used it before but found it neat with how easy it was to use props. Not too sure yet if I will use it more tho

![decorator node merge tag](https://user-images.githubusercontent.com/42207245/215393726-84468639-f732-4a76-8074-4c6519922402.gif)

#### Change
- Install downshift
- Extend merge tag node as decorator node
- Replace button to downshift select dropdown
- Insert tag instead of replacing text