### PR TITLE
Add node transforms

### DIFF
--- a/src/app/components/EditorContainer/index.tsx
+++ b/src/app/components/EditorContainer/index.tsx
@@ -8,6 +8,7 @@ import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin';
 import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
 import { ToolbarPlugin } from '../ToolbarPlugin';
 import { MergeTagNode } from '../CustomNodes/MergeTagNode';
+import { NodeTransform } from '../NodeTransform';
 
 //Definitely check out this first and play with the demo: https://lexical.dev/docs/getting-started/react
 export default function EditorContainer() {
@@ -67,6 +68,7 @@ export default function EditorContainer() {
           />
           <OnChangePlugin onChange={onChange} />
           <HistoryPlugin />
+          <NodeTransform />
         </div>
       </LexicalComposer>
     </div>

--- a/src/app/components/EditorContainer/index.tsx
+++ b/src/app/components/EditorContainer/index.tsx
@@ -9,6 +9,8 @@ import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
 import { ToolbarPlugin } from '../ToolbarPlugin';
 import { MergeTagNode } from '../CustomNodes/MergeTagNode';
 import { NodeTransform } from '../NodeTransform';
+import { useEffect } from 'react';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 
 //Definitely check out this first and play with the demo: https://lexical.dev/docs/getting-started/react
 export default function EditorContainer() {
@@ -54,6 +56,14 @@ export default function EditorContainer() {
     onError,
     nodes: [MergeTagNode], //Custom Nodes
   };
+
+  const AutoFocusPlugin = () => {
+    const [editor] = useLexicalComposerContext();
+    useEffect(() => {
+      editor.focus();
+    }, [editor]);
+    return null;
+  };
   return (
     <div className={styles.Container}>
       <div className={styles.Header}>Lexichan</div>
@@ -69,6 +79,7 @@ export default function EditorContainer() {
           <OnChangePlugin onChange={onChange} />
           <HistoryPlugin />
           <NodeTransform />
+          <AutoFocusPlugin />
         </div>
       </LexicalComposer>
     </div>

--- a/src/app/components/NodeTransform/index.tsx
+++ b/src/app/components/NodeTransform/index.tsx
@@ -2,15 +2,23 @@ import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext
 import { TextNode } from 'lexical';
 import { useEffect } from 'react';
 
+/**
+ * Transforms are the most efficient mechanism to respond to changes to the EditorState
+ * They're exeuted sequentially before changes are propogated to the DOM; multiple transforms still lead to a single DOM reconcilliation
+ * This is important as updating the DOM is the most expensive operation in Lexical's lifecycle
+ * In most cases, it is possible to achieve the same or very similar result through an update listener
+ * However this is discouraged as it triggers an additional render hence stick with transforms
+ * Would need to experiment more on this to better see the use cases
+ */
 export function NodeTransform() {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
     return editor.registerNodeTransform(TextNode, (textNode) => {
-      if (textNode.getTextContent().includes('/') && textNode.getStyle() !== 'color: blue') {
+      if (textNode.getTextContent().includes('blue') && textNode.getStyle() !== 'color: blue') {
         textNode.setStyle('color: blue');
       }
-      if (!textNode.getTextContent().includes('/') && textNode.getStyle() === 'color: blue') {
+      if (!textNode.getTextContent().includes('blue') && textNode.getStyle() === 'color: blue') {
         textNode.setStyle('');
       }
     });

--- a/src/app/components/NodeTransform/index.tsx
+++ b/src/app/components/NodeTransform/index.tsx
@@ -10,6 +10,9 @@ export function NodeTransform() {
       if (textNode.getTextContent().includes('/') && textNode.getStyle() !== 'color: blue') {
         textNode.setStyle('color: blue');
       }
+      if (!textNode.getTextContent().includes('/') && textNode.getStyle() === 'color: blue') {
+        textNode.setStyle('');
+      }
     });
   }, [editor]);
   return null;

--- a/src/app/components/NodeTransform/index.tsx
+++ b/src/app/components/NodeTransform/index.tsx
@@ -1,0 +1,16 @@
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { TextNode } from 'lexical';
+import { useEffect } from 'react';
+
+export function NodeTransform() {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    return editor.registerNodeTransform(TextNode, (textNode) => {
+      if (textNode.getTextContent().includes('/') && textNode.getStyle() !== 'color: blue') {
+        textNode.setStyle('color: blue');
+      }
+    });
+  }, [editor]);
+  return null;
+}

--- a/src/app/components/ToolbarPlugin/index.tsx
+++ b/src/app/components/ToolbarPlugin/index.tsx
@@ -37,10 +37,12 @@ export function ToolbarPlugin() {
    **/
   const updateToolbar = useCallback(() => {
     const selection = $getSelection() as RangeSelection;
-    setIsBold(selection.hasFormat('bold'));
-    setIsItalic(selection.hasFormat('italic'));
-    setIsUnderline(selection.hasFormat('underline'));
-    setIsStrikethrough(selection.hasFormat('strikethrough'));
+    if (selection) {
+      setIsBold(selection.hasFormat('bold'));
+      setIsItalic(selection.hasFormat('italic'));
+      setIsUnderline(selection.hasFormat('underline'));
+      setIsStrikethrough(selection.hasFormat('strikethrough'));
+    }
   }, [activeEditor]);
 
   /**

--- a/src/assets/styles/globals.scss
+++ b/src/assets/styles/globals.scss
@@ -1,11 +1,11 @@
 @import '../styles/variables.scss';
 
 merge-tag {
-  color: $label-blue;
-  background-color: #d8e8f6;
+  color: $label-green;
+  background-color: #cef5d1;
   padding: 2px 4px;
   line-height: 24px;
-  box-shadow: inset 0px -1px 0px #3a8dd1;
+  box-shadow: inset 0px -1px 0px $label-green;
   display: inline;
   pointer-events: none;
 }

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -15,6 +15,7 @@ $bg-gradient-main: linear-gradient(90deg, #69b7eb, #b3dbd3, #f4d6db);
 
 //Label color
 $label-blue: #3a8dd1;
+$label-green: #3ad174;
 
 //Font
 $font-family: 'Neucha', 'Caveat', 'Helvetica Neue', Arial, sans-serif;


### PR DESCRIPTION
#### Context
One of the last concepts left to explore. Possibly the last since the serialisation/deserialisation aspect would require raw data to experiment on. Might be best to do that in the actual codebase than here. Anyway node transforms are simple enough. They're the most efficient mechanism to respond to changes to the EditorState. Slightly similar to how the update listeners functions but one big difference is that this are executed before the DOM gets updated. Quite important as this saves an additional render which is the most expensive lifecycle operation in Lexical

Still unsure how we'll use this for our use cases but it's neat

![node transform example](https://user-images.githubusercontent.com/42207245/215629125-a7398fa2-3262-4126-bbe6-06ca94be6a1a.gif)

#### Change
- Add custom node transform component